### PR TITLE
LKD-153: Embedded Driver For USB Devices

### DIFF
--- a/embedded-uart-common/sample-implementations/linux/sensirion_uart_implementation.c
+++ b/embedded-uart-common/sample-implementations/linux/sensirion_uart_implementation.c
@@ -117,3 +117,6 @@ s16 sensirion_uart_rx(u16 max_data_len, u8 *data) {
 
     return count;
 }
+void sensirion_sleep_usec(u32 useconds) {
+    usleep(useconds_t);
+}

--- a/embedded-uart-common/sensirion_shdlc.c
+++ b/embedded-uart-common/sensirion_shdlc.c
@@ -31,6 +31,7 @@
 #include "sensirion_arch_config.h"
 #include "sensirion_uart.h"
 #include "sensirion_shdlc.h"
+#include "sensirion_sw_i2c_gpio.h"
 
 #define SHDLC_START 0x7e
 #define SHDLC_STOP 0x7e
@@ -41,6 +42,8 @@
 
 /** start/stop + (5 header + 255 data) * 2 because of byte stuffing */
 #define SHDLC_FRAME_MAX_RX_FRAME_SIZE (2 + (5 + 255) * 2)
+
+#define TIME_BETWEEN_TX_AND_RX 20000
 
 static u8 sensirion_shdlc_crc(u8 header_sum, u8 data_len, const u8 *data) {
     header_sum += data_len;
@@ -100,6 +103,7 @@ s16 sensirion_shdlc_xcv(u8 addr, u8 cmd, u8 tx_data_len, const u8 *tx_data,
     if (ret != 0)
         return ret;
 
+    sensirion_sleep_usec(TIME_BETWEEN_TX_AND_RX);
     return sensirion_shdlc_rx(max_rx_data_len, rx_header, rx_data);
 }
 

--- a/embedded-uart-common/sensirion_uart.h
+++ b/embedded-uart-common/sensirion_uart.h
@@ -57,12 +57,22 @@ s16 sensirion_uart_close();
 s16 sensirion_uart_tx(u16 data_len, const u8 *data);
 
 /**
- * sensirion_uart_xx() - receive data over UART
+ * sensirion_uart_rx() - receive data over UART
  *
  * @data_len:   max number of bytes to receive
  * @data:       Memory where received data is stored
  * Return:      Number of bytes received or a negative error code
  */
 s16 sensirion_uart_rx(u16 max_data_len, u8 *data);
+
+/**
+ * Sleep for a given number of microseconds. The function should delay the
+ * execution for at least the given time, but may also sleep longer.
+ *
+ * Despite the unit, a <10 millisecond precision is sufficient.
+ *
+ * @param useconds the sleep time in microseconds
+ */
+void sensirion_sleep_usec(u32 useconds);
 
 #endif /* SENSIRION_UART_H */

--- a/embedded-uart-common/sensirion_uart_implementation.c
+++ b/embedded-uart-common/sensirion_uart_implementation.c
@@ -1,1 +1,95 @@
-sample-implementations/linux/sensirion_uart_implementation.c
+/*
+ * Copyright (c) 2018, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sensirion_uart.h"
+
+/*
+ * INSTRUCTIONS
+ * ============
+ *
+ * Implement all functions where they are marked as TODO: implement.
+ * Follow the function specification in the comments.
+ */
+
+/**
+ * sensirion_uart_open() - initialize UART
+ *
+ * Return:      0 on success, an error code otherwise
+ */
+s16 sensirion_uart_open() {
+    return 0;
+}
+
+/**
+ * sensirion_uart_close() - release UART resources
+ *
+ * Return:      0 on success, an error code otherwise
+ */
+s16 sensirion_uart_close(){
+    // TODO: implement
+    return 0;
+}
+
+/**
+ * sensirion_uart_tx() - transmit data over UART
+ *
+ * @data_len:   number of bytes to send
+ * @data:       data to send
+ * Return:      Number of bytes sent or a negative error code
+ */
+s16 sensirion_uart_tx(u16 data_len, const u8 *data) {
+    // TODO: implement
+    return 0;
+}
+
+/**
+ * sensirion_uart_rx() - receive data over UART
+ *
+ * @data_len:   max number of bytes to receive
+ * @data:       Memory where received data is stored
+ * Return:      Number of bytes received or a negative error code
+ */
+s16 sensirion_uart_rx(u16 max_data_len, u8 *data) {
+    // TODO: implement
+    return 0;
+}
+
+/**
+ * Sleep for a given number of microseconds. The function should delay the
+ * execution for at least the given time, but may also sleep longer.
+ *
+ * Despite the unit, a <10 millisecond precision is sufficient.
+ *
+ * @param useconds the sleep time in microseconds
+ */
+void sensirion_sleep_usec(u32 useconds) {
+    // TODO: implement 
+}
+

--- a/sps30/sps30_example_usage.c
+++ b/sps30/sps30_example_usage.c
@@ -45,7 +45,7 @@ int main(void)
     struct sps30_measurement m;
     char serial[SPS_MAX_SERIAL_LEN];
     u8 auto_clean_days = 4;
-    s8 ret;
+    s16 ret;
 
     while (sensirion_uart_open() != 0) {
         printf("UART init failed\n");
@@ -67,22 +67,22 @@ int main(void)
     else
         printf("SPS Serial: %s\n", serial);
 
-    // u32 auto_clean;
-    // ret = sps30_get_fan_auto_cleaning_interval(&auto_clean);
-    // if (ret)
-    //     printf("error retrieving the auto-clean interval\n");
-    // else
-    //     printf("auto-cleaning interval is %u seconds\n", auto_clean);
+    u32 auto_clean;
+    ret = sps30_get_fan_auto_cleaning_interval(&auto_clean);
+    if (ret)
+        printf("error %d retrieving the auto-clean interval\n", ret);
+    else
+        printf("auto-cleaning interval is %d seconds\n", auto_clean);
 
-    // ret = sps30_set_fan_auto_cleaning_interval_days(auto_clean_days);
-    // if (ret)
-    //     printf("error setting the auto-clean interval\n");
+    ret = sps30_set_fan_auto_cleaning_interval_days(auto_clean_days);
+    if (ret)
+        printf("error %d setting the auto-clean interval\n", ret);
 
-    // ret = sps30_get_fan_auto_cleaning_interval_days(&auto_clean_days);
-    // if (ret)
-    //     printf("error retrieving the auto-clean interval\n");
-    // else
-    //     printf("auto-cleaning interval set to %u days\n", auto_clean_days);
+    ret = sps30_get_fan_auto_cleaning_interval_days(&auto_clean_days);
+    if (ret)
+        printf("error retrieving the auto-clean interval\n");
+    else
+        printf("auto-cleaning interval set to %u days\n", auto_clean_days);
 
     ret = sps30_start_measurement();
     if (ret < 0)


### PR DESCRIPTION
LKD-153: Embedded Driver For USB Devices

* Autoclean interval command was only 4bytes. Add the default subcommand.
* The sensor requires time to read a command and send it again. Therefore
  a usleep is used between tx and rx.
