### PR TITLE
Uart linux debug auto clean

### DIFF
--- a/embedded-uart-common/sample-implementations/linux/sensirion_uart_implementation.c
+++ b/embedded-uart-common/sample-implementations/linux/sensirion_uart_implementation.c
@@ -118,5 +118,5 @@ s16 sensirion_uart_rx(u16 max_data_len, u8 *data) {
     return count;
 }
 void sensirion_sleep_usec(u32 useconds) {
-    usleep(useconds_t);
+    usleep(useconds);
 }


### PR DESCRIPTION
Wrong variable name in sleep-function, caused by copy/paste.
