### PR TITLE
Remove wrong include in sensirion_shdlc.c

### DIFF
--- a/embedded-uart-common/sensirion_shdlc.c
+++ b/embedded-uart-common/sensirion_shdlc.c
@@ -31,7 +31,6 @@
 #include "sensirion_arch_config.h"
 #include "sensirion_uart.h"
 #include "sensirion_shdlc.h"
-#include "sensirion_sw_i2c_gpio.h"
 
 #define SHDLC_START 0x7e
 #define SHDLC_STOP 0x7e


### PR DESCRIPTION
The i2c gpio header is not required and not present in this
project, therefore it is removedRemove wrong include in
sensirion_shdlc.c

The i2c gpio header is not required and not present in this
project, therefore it is removed