### PR TITLE
Update the version used in the Raspberry Pi guide

### DIFF
--- a/docs/getting-started-on-the-raspberry-pi.md
+++ b/docs/getting-started-on-the-raspberry-pi.md
@@ -18,12 +18,12 @@ The shell code examples below use the following convention:
 
 Get the latest release from
 https://github.com/Sensirion/embedded-uart-sps/releases/latest
-(sps30-uart-1.0.0.zip for example)
+(sps30-uart-1.1.0.zip for example)
 
 ```bash
 # on the Raspberry Pi
-$ wget https://github.com/Sensirion/embedded-uart-sps/releases/download/1.0.0/sps30-uart-1.0.0.zip
-$ unzip sps30-uart-1.0.0.zip
+$ wget https://github.com/Sensirion/embedded-uart-sps/releases/download/1.1.0/sps30-uart-1.1.0.zip
+$ unzip sps30-uart-1.1.0.zip
 ```
 
 ## Get Port of the Connected Sensor
@@ -47,7 +47,7 @@ the base folder:
 
 ```bash
 # on the Raspberry Pi
-$ cd sps30-uart-1.0.0
+$ cd sps30-uart-1.1.0
 $ cp sample-implementations/linux/sensirion_uart_implementation.c sensirion_uart_implementation.c
 ```
 
@@ -62,7 +62,7 @@ to match the device you got from the step before.
 Now we are ready to compile and run the sample:
 ```bash
 # on the Raspberry Pi
-$ cd sps30-uart-1.0.0
+$ cd sps30-uart-1.1.0
 $ make
 cc -Wall -I. -I. -I. -c -o sensirion_uart_implementation.o sensirion_uart_implementation.c
 cc -Wall -I. -I. -I. -c -o sensirion_shdlc.o sensirion_shdlc.c


### PR DESCRIPTION
While not strictly necessary it makes it directly copy paste able to
use.