### PR TITLE
Rebuild example if example source changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * `[fixed]` Rebuild when `sps30_example_usage.c` changed (#30)
+
 ## [1.1.0] - 2019-03-07
 
  * `[added]` `sps_get_driver_version()` (#12)

--- a/sps30-uart/Makefile
+++ b/sps30-uart/Makefile
@@ -22,8 +22,8 @@ sensirion_shdlc.o: ${sensirion_uart_dir}/sensirion_shdlc.c
 
 sps30.o: sensirion_shdlc.o ${sps_common_dir}/sps_git_version.c sps30.h sps30.c
 
-sps30_example_usage: ${sensirion_uart_objects} ${sps_common_objects} sps30.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LOADLIBES) $(LDLIBS) sps30_example_usage.c
+sps30_example_usage: ${sensirion_uart_objects} ${sps_common_objects} sps30.o sps30_example_usage.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LOADLIBES) $(LDLIBS)
 
 clean:
 	$(RM) ${all_objects} ${sps_binaries}


### PR DESCRIPTION
Previously changes to the sps30-uart/sps30_example_usage.c file didn't
trigger a rebuild.