### PR TITLE
Update circle-ci image to gcc 5.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
 
     docker:
-        - image: gcc:5.4.0
+        - image: gcc:5.5
 
     steps:
       - checkout


### PR DESCRIPTION
Gcc 5.4 is not supported anymore