### PR TITLE
Automated type conversion

### DIFF
--- a/embedded-uart-common/sample-implementations/arduino/sensirion_uart_implementation.cpp
+++ b/embedded-uart-common/sample-implementations/arduino/sensirion_uart_implementation.cpp
@@ -67,7 +67,7 @@ void SERCOM1_Handler() {
  *
  * Return:      0 on success, an error code otherwise
  */
-s16 sensirion_uart_open() {
+int16_t sensirion_uart_open() {
     Serial2.begin(BAUDRATE);
     pinPeripheral(PIN_UART_TX, PIO_SERCOM);
     pinPeripheral(PIN_UART_RX, PIO_SERCOM);
@@ -83,7 +83,7 @@ s16 sensirion_uart_open() {
  *
  * Return:      0 on success, an error code otherwise
  */
-s16 sensirion_uart_close() {
+int16_t sensirion_uart_close() {
     Serial2.end();
     return 0;
 }
@@ -95,7 +95,7 @@ s16 sensirion_uart_close() {
  * @data:       data to sendv v
  * Return:      Number of bytes sent or a negative error code
  */
-s16 sensirion_uart_tx(u16 data_len, const u8 *data) {
+int16_t sensirion_uart_tx(uint16_t data_len, const uint8_t *data) {
     return Serial2.write(data, data_len);
 }
 
@@ -106,11 +106,11 @@ s16 sensirion_uart_tx(u16 data_len, const u8 *data) {
  * @data:       Memory where received data is stored
  * Return:      Number of bytes received or a negative error code
  */
-s16 sensirion_uart_rx(u16 max_data_len, u8 *data) {
-    s16 i = 0;
+int16_t sensirion_uart_rx(uint16_t max_data_len, uint8_t *data) {
+    int16_t i = 0;
 
     while (Serial2.available() > 0 && i < max_data_len) {
-        data[i] = (u8)Serial2.read();
+        data[i] = (uint8_t)Serial2.read();
         i++;
     }
 
@@ -125,7 +125,7 @@ s16 sensirion_uart_rx(u16 max_data_len, u8 *data) {
  *
  * @param useconds the sleep time in microseconds
  */
-void sensirion_sleep_usec(u32 useconds) {
+void sensirion_sleep_usec(uint32_t useconds) {
     delay((useconds / 1000) + 1);
 }
 

--- a/embedded-uart-common/sample-implementations/linux/sensirion_uart_implementation.c
+++ b/embedded-uart-common/sample-implementations/linux/sensirion_uart_implementation.c
@@ -43,7 +43,7 @@
 
 static int uart_fd = -1;
 
-s16 sensirion_uart_open() {
+int16_t sensirion_uart_open() {
     // The flags (defined in fcntl.h):
     //    Access modes (use 1 of these):
     //        O_RDONLY - Open for reading only.
@@ -84,23 +84,23 @@ s16 sensirion_uart_open() {
     return 0;
 }
 
-s16 sensirion_uart_release() {
+int16_t sensirion_uart_release() {
     return close(uart_fd);
 }
 
-s16 sensirion_uart_tx(u16 data_len, const u8 *data) {
+int16_t sensirion_uart_tx(uint16_t data_len, const uint8_t *data) {
     if (uart_fd == -1)
         return -1;
 
     return write(uart_fd, (void *)data, data_len);
 }
 
-s16 sensirion_uart_rx(u16 max_data_len, u8 *data) {
+int16_t sensirion_uart_rx(uint16_t max_data_len, uint8_t *data) {
     if (uart_fd == -1)
         return -1;
 
     return read(uart_fd, (void *)data, max_data_len);
 }
-void sensirion_sleep_usec(u32 useconds) {
+void sensirion_sleep_usec(uint32_t useconds) {
     usleep(useconds);
 }

--- a/embedded-uart-common/sensirion_arch_config.h
+++ b/embedded-uart-common/sensirion_arch_config.h
@@ -45,7 +45,7 @@ extern "C" {
 /**
  * Typedef section for types commonly defined in <stdint.h>
  * If your system does not provide stdint headers, please define them
- * accordingly. Please make sure to define int64_t and uint64_t.
+ * accordingly.
  */
 /* typedef unsigned long long int uint64_t;
  * typedef long long int int64_t;
@@ -56,21 +56,8 @@ extern "C" {
  * typedef char int8_t;
  * typedef unsigned char uint8_t; */
 
-/**
- * Comment out the following block if your platform already provides the
- * type definitions u8, u16, u32, u64, s8, s16, s32, s64.
- */
-typedef int64_t s64;
-typedef uint64_t u64;
-typedef int32_t s32;
-typedef uint32_t u32;
-typedef int16_t s16;
-typedef uint16_t u16;
-typedef int8_t s8;
-typedef uint8_t u8;
-
 /* Types not typically provided by <stdint.h> */
-typedef float f32;
+typedef float float32_t;
 
 /**
  * Define the endianness of your architecture:

--- a/embedded-uart-common/sensirion_shdlc.c
+++ b/embedded-uart-common/sensirion_shdlc.c
@@ -45,7 +45,8 @@
 
 #define RX_DELAY_US 20000
 
-static u8 sensirion_shdlc_crc(u8 header_sum, u8 data_len, const u8 *data) {
+static uint8_t sensirion_shdlc_crc(uint8_t header_sum, uint8_t data_len,
+                                   const uint8_t *data) {
     header_sum += data_len;
 
     while (data_len--)
@@ -54,10 +55,11 @@ static u8 sensirion_shdlc_crc(u8 header_sum, u8 data_len, const u8 *data) {
     return ~header_sum;
 }
 
-static u16 sensirion_shdlc_stuff_data(u8 data_len, const u8 *data,
-                                      u8 *stuffed_data) {
-    u16 output_data_len = 0;
-    u8 c;
+static uint16_t sensirion_shdlc_stuff_data(uint8_t data_len,
+                                           const uint8_t *data,
+                                           uint8_t *stuffed_data) {
+    uint16_t output_data_len = 0;
+    uint8_t c;
 
     while (data_len--) {
         c = *(data++);
@@ -79,11 +81,11 @@ static u16 sensirion_shdlc_stuff_data(u8 data_len, const u8 *data,
     return output_data_len;
 }
 
-static u8 sensirion_shdlc_check_unstuff(u8 data) {
+static uint8_t sensirion_shdlc_check_unstuff(uint8_t data) {
     return data == 0x7d;
 }
 
-static u8 sensirion_shdlc_unstuff_byte(u8 data) {
+static uint8_t sensirion_shdlc_unstuff_byte(uint8_t data) {
     switch (data) {
         case 0x31:
             return 0x11;
@@ -98,11 +100,11 @@ static u8 sensirion_shdlc_unstuff_byte(u8 data) {
     }
 }
 
-s16 sensirion_shdlc_xcv(u8 addr, u8 cmd, u8 tx_data_len, const u8 *tx_data,
-                        u8 max_rx_data_len,
-                        struct sensirion_shdlc_rx_header *rx_header,
-                        u8 *rx_data) {
-    s16 ret;
+int16_t sensirion_shdlc_xcv(uint8_t addr, uint8_t cmd, uint8_t tx_data_len,
+                            const uint8_t *tx_data, uint8_t max_rx_data_len,
+                            struct sensirion_shdlc_rx_header *rx_header,
+                            uint8_t *rx_data) {
+    int16_t ret;
 
     ret = sensirion_shdlc_tx(addr, cmd, tx_data_len, tx_data);
     if (ret != 0)
@@ -112,11 +114,12 @@ s16 sensirion_shdlc_xcv(u8 addr, u8 cmd, u8 tx_data_len, const u8 *tx_data,
     return sensirion_shdlc_rx(max_rx_data_len, rx_header, rx_data);
 }
 
-s16 sensirion_shdlc_tx(u8 addr, u8 cmd, u8 data_len, const u8 *data) {
-    u16 len = 0;
-    s16 ret;
-    u8 crc;
-    u8 tx_frame_buf[SHDLC_FRAME_MAX_TX_FRAME_SIZE];
+int16_t sensirion_shdlc_tx(uint8_t addr, uint8_t cmd, uint8_t data_len,
+                           const uint8_t *data) {
+    uint16_t len = 0;
+    int16_t ret;
+    uint8_t crc;
+    uint8_t tx_frame_buf[SHDLC_FRAME_MAX_TX_FRAME_SIZE];
 
     crc = sensirion_shdlc_crc(addr + cmd, data_len, data);
 
@@ -136,17 +139,18 @@ s16 sensirion_shdlc_tx(u8 addr, u8 cmd, u8 data_len, const u8 *data) {
     return 0;
 }
 
-s16 sensirion_shdlc_rx(u8 max_data_len, struct sensirion_shdlc_rx_header *rxh,
-                       u8 *data) {
-    u16 len;
-    u16 i;
-    u8 rx_frame[SHDLC_FRAME_MAX_RX_FRAME_SIZE];
-    u8 *rx_header = (u8 *)rxh;
-    u8 j;
-    u8 crc;
-    u8 unstuff_next;
+int16_t sensirion_shdlc_rx(uint8_t max_data_len,
+                           struct sensirion_shdlc_rx_header *rxh,
+                           uint8_t *data) {
+    uint16_t len;
+    uint16_t i;
+    uint8_t rx_frame[SHDLC_FRAME_MAX_RX_FRAME_SIZE];
+    uint8_t *rx_header = (uint8_t *)rxh;
+    uint8_t j;
+    uint8_t crc;
+    uint8_t unstuff_next;
 
-    len = sensirion_uart_rx(2 + (5 + (u16)max_data_len) * 2, rx_frame);
+    len = sensirion_uart_rx(2 + (5 + (uint16_t)max_data_len) * 2, rx_frame);
     if (len < 1 || rx_frame[0] != SHDLC_START)
         return SENSIRION_SHDLC_ERR_MISSING_START;
 

--- a/embedded-uart-common/sensirion_shdlc.h
+++ b/embedded-uart-common/sensirion_shdlc.h
@@ -50,18 +50,19 @@ extern "C" {
 #define be32_to_cpu(s) (s)
 #define be64_to_cpu(s) (s)
 #else
-#define be16_to_cpu(s) (((u16)(s) << 8) | (0xff & ((u16)(s)) >> 8))
+#define be16_to_cpu(s) (((uint16_t)(s) << 8) | (0xff & ((uint16_t)(s)) >> 8))
 #define be32_to_cpu(s)                                                         \
-    (((u32)be16_to_cpu(s) << 16) | (0xffff & (be16_to_cpu((s) >> 16))))
+    (((uint32_t)be16_to_cpu(s) << 16) | (0xffff & (be16_to_cpu((s) >> 16))))
 #define be64_to_cpu(s)                                                         \
-    (((u64)be32_to_cpu(s) << 32) | (0xffffffff & ((u64)be32_to_cpu((s) >> 32))))
+    (((uint64_t)be32_to_cpu(s) << 32) |                                        \
+     (0xffffffff & ((uint64_t)be32_to_cpu((s) >> 32))))
 #endif
 
 struct sensirion_shdlc_rx_header {
-    u8 addr;
-    u8 cmd;
-    u8 state;
-    u8 data_len;
+    uint8_t addr;
+    uint8_t cmd;
+    uint8_t state;
+    uint8_t data_len;
 };
 
 /**
@@ -73,7 +74,8 @@ struct sensirion_shdlc_rx_header {
  * @data:       data to send
  * Return:      0 on success, an error code otherwise
  */
-s16 sensirion_shdlc_tx(u8 addr, u8 cmd, u8 data_len, const u8 *data);
+int16_t sensirion_shdlc_tx(uint8_t addr, uint8_t cmd, uint8_t data_len,
+                           const uint8_t *data);
 
 /**
  * sensirion_shdlc_rx() - receive an SHDLC frame
@@ -86,8 +88,9 @@ s16 sensirion_shdlc_tx(u8 addr, u8 cmd, u8 data_len, const u8 *data);
  * @data:       Memory where received data is stored
  * Return:      0 on success, an error code otherwise
  */
-s16 sensirion_shdlc_rx(u8 max_data_len,
-                       struct sensirion_shdlc_rx_header *header, u8 *data);
+int16_t sensirion_shdlc_rx(uint8_t max_data_len,
+                           struct sensirion_shdlc_rx_header *header,
+                           uint8_t *data);
 
 /**
  * sensirion_shdlc_xcv() - transceive (transmit then receive) an SHDLC frame
@@ -103,10 +106,10 @@ s16 sensirion_shdlc_rx(u8 max_data_len,
  * @rx_data:        Memory where the received data is stored
  * Return:          0 on success, an error code otherwise
  */
-s16 sensirion_shdlc_xcv(u8 addr, u8 cmd, u8 tx_data_len, const u8 *tx_data,
-                        u8 max_rx_data_len,
-                        struct sensirion_shdlc_rx_header *rx_header,
-                        u8 *rx_data);
+int16_t sensirion_shdlc_xcv(uint8_t addr, uint8_t cmd, uint8_t tx_data_len,
+                            const uint8_t *tx_data, uint8_t max_rx_data_len,
+                            struct sensirion_shdlc_rx_header *rx_header,
+                            uint8_t *rx_data);
 
 #ifdef __cplusplus
 }

--- a/embedded-uart-common/sensirion_uart.h
+++ b/embedded-uart-common/sensirion_uart.h
@@ -43,14 +43,14 @@ extern "C" {
  *
  * Return:      0 on success, an error code otherwise
  */
-s16 sensirion_uart_open();
+int16_t sensirion_uart_open();
 
 /**
  * sensirion_uart_close() - release UART resources
  *
  * Return:      0 on success, an error code otherwise
  */
-s16 sensirion_uart_close();
+int16_t sensirion_uart_close();
 
 /**
  * sensirion_uart_tx() - transmit data over UART
@@ -59,7 +59,7 @@ s16 sensirion_uart_close();
  * @data:       data to send
  * Return:      Number of bytes sent or a negative error code
  */
-s16 sensirion_uart_tx(u16 data_len, const u8 *data);
+int16_t sensirion_uart_tx(uint16_t data_len, const uint8_t *data);
 
 /**
  * sensirion_uart_rx() - receive data over UART
@@ -68,7 +68,7 @@ s16 sensirion_uart_tx(u16 data_len, const u8 *data);
  * @data:       Memory where received data is stored
  * Return:      Number of bytes received or a negative error code
  */
-s16 sensirion_uart_rx(u16 max_data_len, u8 *data);
+int16_t sensirion_uart_rx(uint16_t max_data_len, uint8_t *data);
 
 /**
  * Sleep for a given number of microseconds. The function should delay the
@@ -78,7 +78,7 @@ s16 sensirion_uart_rx(u16 max_data_len, u8 *data);
  *
  * @param useconds the sleep time in microseconds
  */
-void sensirion_sleep_usec(u32 useconds);
+void sensirion_sleep_usec(uint32_t useconds);
 
 #ifdef __cplusplus
 }

--- a/embedded-uart-common/sensirion_uart_implementation.c
+++ b/embedded-uart-common/sensirion_uart_implementation.c
@@ -45,7 +45,7 @@
  *
  * Return:      0 on success, an error code otherwise
  */
-s16 sensirion_uart_open() {
+int16_t sensirion_uart_open() {
     return 0;
 }
 
@@ -54,7 +54,7 @@ s16 sensirion_uart_open() {
  *
  * Return:      0 on success, an error code otherwise
  */
-s16 sensirion_uart_close() {
+int16_t sensirion_uart_close() {
     // TODO: implement
     return 0;
 }
@@ -66,7 +66,7 @@ s16 sensirion_uart_close() {
  * @data:       data to send
  * Return:      Number of bytes sent or a negative error code
  */
-s16 sensirion_uart_tx(u16 data_len, const u8 *data) {
+int16_t sensirion_uart_tx(uint16_t data_len, const uint8_t *data) {
     // TODO: implement
     return 0;
 }
@@ -78,7 +78,7 @@ s16 sensirion_uart_tx(u16 data_len, const u8 *data) {
  * @data:       Memory where received data is stored
  * Return:      Number of bytes received or a negative error code
  */
-s16 sensirion_uart_rx(u16 max_data_len, u8 *data) {
+int16_t sensirion_uart_rx(uint16_t max_data_len, uint8_t *data) {
     // TODO: implement
     return 0;
 }
@@ -91,6 +91,6 @@ s16 sensirion_uart_rx(u16 max_data_len, u8 *data) {
  *
  * @param useconds the sleep time in microseconds
  */
-void sensirion_sleep_usec(u32 useconds) {
+void sensirion_sleep_usec(uint32_t useconds) {
     // TODO: implement
 }

--- a/sps30-uart/sps30.c
+++ b/sps30-uart/sps30.c
@@ -53,21 +53,21 @@ const char *sps_get_driver_version() {
     return SPS_DRV_VERSION_STR;
 }
 
-s16 sps30_probe() {
+int16_t sps30_probe() {
     char serial[SPS_MAX_SERIAL_LEN];
-    s16 ret = sps30_get_serial(serial);
+    int16_t ret = sps30_get_serial(serial);
 
     return ret;
 }
 
-s16 sps30_get_serial(char *serial) {
+int16_t sps30_get_serial(char *serial) {
     struct sensirion_shdlc_rx_header header;
-    u8 param_buf[] = SPS_CMD_DEV_INFO_SUBCMD_GET_SERIAL;
-    s16 ret;
+    uint8_t param_buf[] = SPS_CMD_DEV_INFO_SUBCMD_GET_SERIAL;
+    int16_t ret;
 
     ret = sensirion_shdlc_xcv(SPS_ADDR, SPS_CMD_DEV_INFO, sizeof(param_buf),
                               param_buf, SPS_MAX_SERIAL_LEN, &header,
-                              (u8 *)serial);
+                              (uint8_t *)serial);
     if (ret < 0)
         return ret;
 
@@ -77,27 +77,27 @@ s16 sps30_get_serial(char *serial) {
     return 0;
 }
 
-s16 sps30_start_measurement() {
-    u8 param_buf[] = SPS_SUBCMD_MEASUREMENT_START;
+int16_t sps30_start_measurement() {
+    uint8_t param_buf[] = SPS_SUBCMD_MEASUREMENT_START;
 
     return sensirion_shdlc_tx(SPS_ADDR, SPS_CMD_START_MEASUREMENT,
                               sizeof(param_buf), param_buf);
 }
 
-s16 sps30_stop_measurement() {
+int16_t sps30_stop_measurement() {
     return sensirion_shdlc_tx(SPS_ADDR, SPS_CMD_STOP_MEASUREMENT, 0, NULL);
 }
 
-s16 sps30_read_measurement(struct sps30_measurement *measurement) {
+int16_t sps30_read_measurement(struct sps30_measurement *measurement) {
     struct sensirion_shdlc_rx_header header;
-    f32 data[10];
-    s16 ret;
-    u16 idx;
-    u32 *u32_data = (u32 *)data;
-    u32 tmp;
+    float32_t data[10];
+    int16_t ret;
+    uint16_t idx;
+    uint32_t *u32_data = (uint32_t *)data;
+    uint32_t tmp;
 
     ret = sensirion_shdlc_xcv(SPS_ADDR, SPS_CMD_READ_MEASUREMENT, 0, NULL,
-                              sizeof(data), &header, (u8 *)data);
+                              sizeof(data), &header, (uint8_t *)data);
     if (ret)
         return ret;
 
@@ -106,34 +106,34 @@ s16 sps30_read_measurement(struct sps30_measurement *measurement) {
 
     idx = 0;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->mc_1p0 = *(f32 *)&tmp;
+    measurement->mc_1p0 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->mc_2p5 = *(f32 *)&tmp;
+    measurement->mc_2p5 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->mc_4p0 = *(f32 *)&tmp;
+    measurement->mc_4p0 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->mc_10p0 = *(f32 *)&tmp;
+    measurement->mc_10p0 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->nc_0p5 = *(f32 *)&tmp;
+    measurement->nc_0p5 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->nc_1p0 = *(f32 *)&tmp;
+    measurement->nc_1p0 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->nc_2p5 = *(f32 *)&tmp;
+    measurement->nc_2p5 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->nc_4p0 = *(f32 *)&tmp;
+    measurement->nc_4p0 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->nc_10p0 = *(f32 *)&tmp;
+    measurement->nc_10p0 = *(float32_t *)&tmp;
     ++idx;
     tmp = be32_to_cpu(u32_data[idx]);
-    measurement->typical_particle_size = *(f32 *)&tmp;
+    measurement->typical_particle_size = *(float32_t *)&tmp;
     ++idx;
 
     if (header.state)
@@ -142,12 +142,12 @@ s16 sps30_read_measurement(struct sps30_measurement *measurement) {
     return 0;
 }
 
-s16 sps30_read_fan_speed(u16 *fan_rpm) {
+int16_t sps30_read_fan_speed(uint16_t *fan_rpm) {
     struct sensirion_shdlc_rx_header header;
-    s16 ret;
+    int16_t ret;
 
     ret = sensirion_shdlc_xcv(SPS_ADDR, SPS_CMD_READ_FAN_SPEED, 0, NULL,
-                              sizeof(*fan_rpm), &header, (u8 *)fan_rpm);
+                              sizeof(*fan_rpm), &header, (uint8_t *)fan_rpm);
     if (ret < 0)
         return ret;
 
@@ -158,14 +158,14 @@ s16 sps30_read_fan_speed(u16 *fan_rpm) {
     return 0;
 }
 
-s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds) {
+int16_t sps30_get_fan_auto_cleaning_interval(uint32_t *interval_seconds) {
     struct sensirion_shdlc_rx_header header;
-    u8 tx_data[] = {SPS_SUBCMD_READ_FAN_CLEAN_INTV};
-    s16 ret;
+    uint8_t tx_data[] = {SPS_SUBCMD_READ_FAN_CLEAN_INTV};
+    int16_t ret;
 
     ret = sensirion_shdlc_xcv(SPS_ADDR, SPS_CMD_FAN_CLEAN_INTV, sizeof(tx_data),
                               tx_data, sizeof(*interval_seconds), &header,
-                              (u8 *)interval_seconds);
+                              (uint8_t *)interval_seconds);
     if (ret < 0)
         return ret;
 
@@ -177,24 +177,24 @@ s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds) {
     return 0;
 }
 
-s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds) {
+int16_t sps30_set_fan_auto_cleaning_interval(uint32_t interval_seconds) {
     struct sensirion_shdlc_rx_header header;
-    u8 ix;
-    u8 cleaning_command[SPS_CMD_FAN_CLEAN_LENGTH];
-    u32 value = be32_to_cpu(interval_seconds);
+    uint8_t ix;
+    uint8_t cleaning_command[SPS_CMD_FAN_CLEAN_LENGTH];
+    uint32_t value = be32_to_cpu(interval_seconds);
 
     cleaning_command[0] = SPS_SUBCMD_READ_FAN_CLEAN_INTV;
-    for (ix = 0; ix < sizeof(u32); ix++)
-        cleaning_command[ix + 1] = (u8)(value >> (8 * ix));
+    for (ix = 0; ix < sizeof(uint32_t); ix++)
+        cleaning_command[ix + 1] = (uint8_t)(value >> (8 * ix));
     return sensirion_shdlc_xcv(
         SPS_ADDR, SPS_CMD_FAN_CLEAN_INTV, sizeof(cleaning_command),
-        (const u8 *)cleaning_command, sizeof(interval_seconds), &header,
-        (u8 *)&interval_seconds);
+        (const uint8_t *)cleaning_command, sizeof(interval_seconds), &header,
+        (uint8_t *)&interval_seconds);
 }
 
-s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days) {
-    s16 ret;
-    u32 interval_seconds;
+int16_t sps30_get_fan_auto_cleaning_interval_days(uint8_t *interval_days) {
+    int16_t ret;
+    uint32_t interval_seconds;
 
     ret = sps30_get_fan_auto_cleaning_interval(&interval_seconds);
     if (ret < 0)
@@ -204,11 +204,11 @@ s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days) {
     return ret;
 }
 
-s16 sps30_set_fan_auto_cleaning_interval_days(u8 interval_days) {
-    return sps30_set_fan_auto_cleaning_interval((u32)interval_days * 24 * 60 *
-                                                60);
+int16_t sps30_set_fan_auto_cleaning_interval_days(uint8_t interval_days) {
+    return sps30_set_fan_auto_cleaning_interval((uint32_t)interval_days * 24 *
+                                                60 * 60);
 }
 
-s16 sps30_reset() {
+int16_t sps30_reset() {
     return sensirion_shdlc_tx(SPS_ADDR, SPS_CMD_RESET, 0, NULL);
 }

--- a/sps30-uart/sps30.h
+++ b/sps30-uart/sps30.h
@@ -45,16 +45,16 @@ extern "C" {
 #define SPS_GET_ERR_STATE(err_code) ((err_code)&0xff)
 
 struct sps30_measurement {
-    f32 mc_1p0;
-    f32 mc_2p5;
-    f32 mc_4p0;
-    f32 mc_10p0;
-    f32 nc_0p5;
-    f32 nc_1p0;
-    f32 nc_2p5;
-    f32 nc_4p0;
-    f32 nc_10p0;
-    f32 typical_particle_size;
+    float32_t mc_1p0;
+    float32_t mc_2p5;
+    float32_t mc_4p0;
+    float32_t mc_10p0;
+    float32_t nc_0p5;
+    float32_t nc_1p0;
+    float32_t nc_2p5;
+    float32_t nc_4p0;
+    float32_t nc_10p0;
+    float32_t typical_particle_size;
 };
 
 /**
@@ -68,7 +68,7 @@ const char *sps_get_driver_version(void);
  *
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_probe();
+int16_t sps30_probe();
 
 /**
  * sps30_get_serial() - retrieve the serial number
@@ -79,7 +79,7 @@ s16 sps30_probe();
  *          terminated). Must be at least SPS_MAX_SERIAL_LEN long.
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_get_serial(char *serial);
+int16_t sps30_get_serial(char *serial);
 
 /**
  * sps30_start_measurement() - start measuring
@@ -89,14 +89,14 @@ s16 sps30_get_serial(char *serial);
  *
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_start_measurement();
+int16_t sps30_start_measurement();
 
 /**
  * sps30_stop_measurement() - stop measuring
  *
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_stop_measurement();
+int16_t sps30_stop_measurement();
 
 /**
  * sps30_read_measurement() - read a measurement
@@ -105,7 +105,7 @@ s16 sps30_stop_measurement();
  *
  * Return:  0 on success, an error code otherwise
  */
-s16 sps30_read_measurement(struct sps30_measurement *measurement);
+int16_t sps30_read_measurement(struct sps30_measurement *measurement);
 
 /**
  * sps30_read_fan_speed() - read the current fan speed
@@ -115,7 +115,7 @@ s16 sps30_read_measurement(struct sps30_measurement *measurement);
  * @fan_rpm:    Memory where the fan speed in rpm is stored
  * Return:      0 on success, an error code otherwise
  */
-s16 sps30_read_fan_speed(u16 *fan_rpm);
+int16_t sps30_read_fan_speed(uint16_t *fan_rpm);
 
 /**
  * sps30_get_fan_auto_cleaning_interval() - read the current auto-cleaning
@@ -127,7 +127,7 @@ s16 sps30_read_fan_speed(u16 *fan_rpm);
  * @interval_seconds:   Memory where the interval in seconds is stored
  * Return:              0 on success, an error code otherwise
  */
-s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds);
+int16_t sps30_get_fan_auto_cleaning_interval(uint32_t *interval_seconds);
 
 /**
  * sps30_set_fan_auto_cleaning_interval() - set the current auto-cleaning
@@ -136,7 +136,7 @@ s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds);
  * @interval_seconds:   Value in seconds used to sets the auto-cleaning interval
  * Return:              0 on success, an error code otherwise
  */
-s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds);
+int16_t sps30_set_fan_auto_cleaning_interval(uint32_t interval_seconds);
 
 /**
  * sps30_get_fan_auto_cleaning_interval_days() - convenience function to read
@@ -152,7 +152,7 @@ s16 sps30_set_fan_auto_cleaning_interval(u32 interval_seconds);
  * @interval_days:  Memory where the interval in days is stored
  * Return:          0 on success, an error code otherwise
  */
-s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days);
+int16_t sps30_get_fan_auto_cleaning_interval_days(uint8_t *interval_days);
 
 /**
  * sps30_set_fan_auto_cleaning_interval_days() - convenience function to set the
@@ -161,14 +161,14 @@ s16 sps30_get_fan_auto_cleaning_interval_days(u8 *interval_days);
  * @interval_days:  Value in days used to sets the auto-cleaning interval
  * Return:          0 on success, an error code otherwise
  */
-s16 sps30_set_fan_auto_cleaning_interval_days(u8 interval_days);
+int16_t sps30_set_fan_auto_cleaning_interval_days(uint8_t interval_days);
 
 /**
  * sps30_reset() - reset the SGP30
  *
  * Return:          0 on success, an error code otherwise
  */
-s16 sps30_reset();
+int16_t sps30_reset();
 
 #ifdef __cplusplus
 }

--- a/sps30-uart/sps30_example_usage.c
+++ b/sps30-uart/sps30_example_usage.c
@@ -45,9 +45,9 @@
 int main(void) {
     struct sps30_measurement m;
     char serial[SPS_MAX_SERIAL_LEN];
-    u8 auto_clean_days = 4;
-    u32 auto_clean;
-    s16 ret;
+    uint8_t auto_clean_days = 4;
+    uint32_t auto_clean;
+    int16_t ret;
 
     while (sensirion_uart_open() != 0) {
         printf("UART init failed\n");

--- a/sps30-uart/test_projects/Arduino/arduino_sps30_example/arduino_sps30_example.ino
+++ b/sps30-uart/test_projects/Arduino/arduino_sps30_example/arduino_sps30_example.ino
@@ -47,7 +47,7 @@ void setup() {
 
 void loop() {
     struct sps30_measurement measurement;
-    s16 ret;
+    int16_t ret;
 
     while (sps30_probe() != 0) {
         Serial.write("probe failed\n");


### PR DESCRIPTION
This patch includes the changes from the following commands:

find . -type f \
    \( -name '*\.[ch]' -o -name '*\.cpp' -o -name '*\.ino' \) -print0 \
    | xargs -0 sed -i \
    -e 's/\bu\([0-9]\{1,2\}\)\b/uint\1_t/g' \
    -e 's/\bs\([0-9]\{1,2\}\)\b/int\1_t/g' \
    -e 's/\bf32\b/float32_t/g'
make style-fix

Manual tweak to sensirion_arch_config.h