### PR TITLE
SPS30: C-compatible functions

### DIFF
--- a/sps30-uart/sps30.c
+++ b/sps30-uart/sps30.c
@@ -50,11 +50,11 @@
 #define SPS30_CMD_RESET 0xd3
 #define SPS30_ERR_STATE(state) (SPS30_ERR_STATE_MASK | (state))
 
-const char *sps_get_driver_version() {
+const char *sps_get_driver_version(void) {
     return SPS_DRV_VERSION_STR;
 }
 
-int16_t sps30_probe() {
+int16_t sps30_probe(void) {
     char serial[SPS30_MAX_SERIAL_LEN];
     int16_t ret = sps30_get_serial(serial);
 
@@ -78,7 +78,7 @@ int16_t sps30_get_serial(char *serial) {
     return 0;
 }
 
-int16_t sps30_start_measurement() {
+int16_t sps30_start_measurement(void) {
     struct sensirion_shdlc_rx_header header;
     uint8_t param_buf[] = SPS30_SUBCMD_MEASUREMENT_START;
 
@@ -86,7 +86,7 @@ int16_t sps30_start_measurement() {
                                sizeof(param_buf), param_buf, 0, &header, NULL);
 }
 
-int16_t sps30_stop_measurement() {
+int16_t sps30_stop_measurement(void) {
     struct sensirion_shdlc_rx_header header;
 
     return sensirion_shdlc_xcv(SPS30_ADDR, SPS30_CMD_STOP_MEASUREMENT, 0, NULL,
@@ -199,13 +199,13 @@ int16_t sps30_set_fan_auto_cleaning_interval_days(uint8_t interval_days) {
                                                 60 * 60);
 }
 
-int16_t sps30_start_manual_fan_cleaning() {
+int16_t sps30_start_manual_fan_cleaning(void) {
     struct sensirion_shdlc_rx_header header;
 
     return sensirion_shdlc_xcv(SPS30_ADDR, SPS30_CMD_START_FAN_CLEANING, 0,
                                NULL, 0, &header, NULL);
 }
 
-int16_t sps30_reset() {
+int16_t sps30_reset(void) {
     return sensirion_shdlc_tx(SPS30_ADDR, SPS30_CMD_RESET, 0, NULL);
 }

--- a/sps30-uart/sps30.h
+++ b/sps30-uart/sps30.h
@@ -68,7 +68,7 @@ const char *sps_get_driver_version(void);
  *
  * Return:  0 on success, an error code otherwise
  */
-int16_t sps30_probe();
+int16_t sps30_probe(void);
 
 /**
  * sps30_get_serial() - retrieve the serial number
@@ -89,14 +89,14 @@ int16_t sps30_get_serial(char *serial);
  *
  * Return:  0 on success, an error code otherwise
  */
-int16_t sps30_start_measurement();
+int16_t sps30_start_measurement(void);
 
 /**
  * sps30_stop_measurement() - stop measuring
  *
  * Return:  0 on success, an error code otherwise
  */
-int16_t sps30_stop_measurement();
+int16_t sps30_stop_measurement(void);
 
 /**
  * sps30_read_measurement() - read a measurement
@@ -162,14 +162,14 @@ int16_t sps30_set_fan_auto_cleaning_interval_days(uint8_t interval_days);
  *
  * Return:          0 on success, an error code otherwise
  */
-int16_t sps30_start_manual_fan_cleaning();
+int16_t sps30_start_manual_fan_cleaning(void);
 
 /**
  * sps30_reset() - reset the SGP30
  *
  * Return:          0 on success, an error code otherwise
  */
-int16_t sps30_reset();
+int16_t sps30_reset(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Rename foo() to foo(void)

Check the following:

 - [x] Code style cleaned (ran `make style-fix`)
 - [ ] Tested on actual hardware
