### PR TITLE
arch_config: Remove float32_t typedef

### DIFF
--- a/embedded-uart-common/sensirion_arch_config.h
+++ b/embedded-uart-common/sensirion_arch_config.h
@@ -56,9 +56,6 @@ extern "C" {
  * typedef char int8_t;
  * typedef unsigned char uint8_t; */
 
-/* Types not typically provided by <stdint.h> */
-typedef float float32_t;
-
 /**
  * Define the endianness of your architecture:
  * 0: little endian, 1: big endian

--- a/sps30-uart/sps30.c
+++ b/sps30-uart/sps30.c
@@ -99,7 +99,7 @@ int16_t sps30_read_measurement(struct sps30_measurement *measurement) {
     union {
         uint16_t u16_value[2];
         uint32_t u32_value;
-        float32_t f32_value;
+        float f32_value;
     } val, data[10];
 
     ret = sensirion_shdlc_xcv(SPS30_ADDR, SPS30_CMD_READ_MEASUREMENT, 0, NULL,

--- a/sps30-uart/sps30.h
+++ b/sps30-uart/sps30.h
@@ -45,16 +45,16 @@ extern "C" {
 #define SPS30_GET_ERR_STATE(err_code) ((err_code)&0xff)
 
 struct sps30_measurement {
-    float32_t mc_1p0;
-    float32_t mc_2p5;
-    float32_t mc_4p0;
-    float32_t mc_10p0;
-    float32_t nc_0p5;
-    float32_t nc_1p0;
-    float32_t nc_2p5;
-    float32_t nc_4p0;
-    float32_t nc_10p0;
-    float32_t typical_particle_size;
+    float mc_1p0;
+    float mc_2p5;
+    float mc_4p0;
+    float mc_10p0;
+    float nc_0p5;
+    float nc_1p0;
+    float nc_2p5;
+    float nc_4p0;
+    float nc_10p0;
+    float typical_particle_size;
 };
 
 /**


### PR DESCRIPTION
float is defined to be a single precision floating point type and on
almost all platforms it is a IEEE-754 32 bit floating point. A platform
not supporting IEEE-754 is out of scope for this driver.

Check the following:

 - [na] Breaking changes marked in commit message
 - [na] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [na] Tested on actual hardware
