### PR TITLE
Remove legacy endianness conversion macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ * [`changed`] Use configuration independent endianness conversions: no need to
+               define `SENSIRION_BIG_ENDIAN` anymore.
+
 ## [3.1.0] - 2020-07-03
 
  * [`added`]   Get version information with `sps30_read_version` 

--- a/embedded-uart-common/sensirion_arch_config.h
+++ b/embedded-uart-common/sensirion_arch_config.h
@@ -56,32 +56,6 @@ extern "C" {
  * typedef char int8_t;
  * typedef unsigned char uint8_t; */
 
-/**
- * Define the endianness of your architecture:
- * 0: little endian, 1: big endian
- * Use the following code to determine if unsure:
- * ```c
- * #include <stdio.h>
- *
- * int is_big_endian(void) {
- *     union {
- *         unsigned int u;
- *         char c[sizeof(unsigned int)];
- *     } e = { 0 };
- *     e.c[0] = 1;
- *
- *     return (e.i != 1);
- * }
- *
- * int main(void) {
- *     printf("Use #define SENSIRION_BIG_ENDIAN %d\n", is_big_endian());
- *
- *     return 0;
- * }
- * ```
- */
-#define SENSIRION_BIG_ENDIAN 0
-
 #ifndef NULL
 #define NULL ((void*)0)
 #endif

--- a/embedded-uart-common/sensirion_shdlc.c
+++ b/embedded-uart-common/sensirion_shdlc.c
@@ -60,6 +60,13 @@ float sensirion_bytes_to_float(const uint8_t* bytes) {
     return tmp.float32;
 }
 
+void sensirion_uint32_t_to_bytes(uint32_t value, uint8_t* bytes) {
+    bytes[0] = value >> 24;
+    bytes[1] = value >> 16;
+    bytes[2] = value >> 8;
+    bytes[3] = value;
+}
+
 static uint8_t sensirion_shdlc_crc(uint8_t header_sum, uint8_t data_len,
                                    const uint8_t* data) {
     header_sum += data_len;

--- a/embedded-uart-common/sensirion_shdlc.c
+++ b/embedded-uart-common/sensirion_shdlc.c
@@ -45,6 +45,21 @@
 
 #define RX_DELAY_US 20000
 
+uint32_t sensirion_bytes_to_uint32_t(const uint8_t* bytes) {
+    return (uint32_t)bytes[0] << 24 | (uint32_t)bytes[1] << 16 |
+           (uint32_t)bytes[2] << 8 | (uint32_t)bytes[3];
+}
+
+float sensirion_bytes_to_float(const uint8_t* bytes) {
+    union {
+        uint32_t u32_value;
+        float float32;
+    } tmp;
+
+    tmp.u32_value = sensirion_bytes_to_uint32_t(bytes);
+    return tmp.float32;
+}
+
 static uint8_t sensirion_shdlc_crc(uint8_t header_sum, uint8_t data_len,
                                    const uint8_t* data) {
     header_sum += data_len;

--- a/embedded-uart-common/sensirion_shdlc.h
+++ b/embedded-uart-common/sensirion_shdlc.h
@@ -46,19 +46,6 @@ extern "C" {
 #define SENSIRION_SHDLC_ERR_TX_INCOMPLETE -6
 #define SENSIRION_SHDLC_ERR_FRAME_TOO_LONG -7
 
-#if SENSIRION_BIG_ENDIAN
-#define be16_to_cpu(s) (s)
-#define be32_to_cpu(s) (s)
-#define be64_to_cpu(s) (s)
-#else
-#define be16_to_cpu(s) (((uint16_t)(s) << 8) | (0xff & ((uint16_t)(s)) >> 8))
-#define be32_to_cpu(s) \
-    (((uint32_t)be16_to_cpu(s) << 16) | (0xffff & (be16_to_cpu((s) >> 16))))
-#define be64_to_cpu(s)                  \
-    (((uint64_t)be32_to_cpu(s) << 32) | \
-     (0xffffffff & ((uint64_t)be32_to_cpu((s) >> 32))))
-#endif
-
 /**
  * sensirion_bytes_to_uint32_t() - Convert an array of bytes to an uint32_t
  *

--- a/embedded-uart-common/sensirion_shdlc.h
+++ b/embedded-uart-common/sensirion_shdlc.h
@@ -81,6 +81,17 @@ uint32_t sensirion_bytes_to_uint32_t(const uint8_t* bytes);
  */
 float sensirion_bytes_to_float(const uint8_t* bytes);
 
+/**
+ * sensirion_uint32_t_to_bytes() - Convert an uint32_t to an array of bytes
+ *
+ * Convert an uint33_t value in system-endianness to big-endian/MBS-first
+ * format to send to the sensor.
+ *
+ * @param value Value to convert
+ * @param bytes An array of at least four bytes
+ */
+void sensirion_uint32_t_to_bytes(uint32_t value, uint8_t* bytes);
+
 struct sensirion_shdlc_rx_header {
     uint8_t addr;
     uint8_t cmd;

--- a/embedded-uart-common/sensirion_shdlc.h
+++ b/embedded-uart-common/sensirion_shdlc.h
@@ -59,6 +59,28 @@ extern "C" {
      (0xffffffff & ((uint64_t)be32_to_cpu((s) >> 32))))
 #endif
 
+/**
+ * sensirion_bytes_to_uint32_t() - Convert an array of bytes to an uint32_t
+ *
+ * Convert an array of bytes received from the sensor in big-endian/MSB-first
+ * format to an uint32_t value in the correct system-endianness.
+ *
+ * @param bytes An array of at least four bytes (MSB first)
+ * @return      The byte array represented as uint32_t
+ */
+uint32_t sensirion_bytes_to_uint32_t(const uint8_t* bytes);
+
+/**
+ * sensirion_bytes_to_float() - Convert an array of bytes to a float
+ *
+ * Convert an array of bytes received from the sensor in big-endian/MSB-first
+ * format to an float value in the correct system-endianness.
+ *
+ * @param bytes An array of at least four bytes (MSB first)
+ * @return      The byte array represented as float
+ */
+float sensirion_bytes_to_float(const uint8_t* bytes);
+
 struct sensirion_shdlc_rx_header {
     uint8_t addr;
     uint8_t cmd;

--- a/sps30-uart/sps30.c
+++ b/sps30-uart/sps30.c
@@ -173,17 +173,14 @@ int16_t sps30_get_fan_auto_cleaning_interval(uint32_t* interval_seconds) {
 
 int16_t sps30_set_fan_auto_cleaning_interval(uint32_t interval_seconds) {
     struct sensirion_shdlc_rx_header header;
-    uint8_t ix;
     uint8_t cleaning_command[SPS30_CMD_FAN_CLEAN_INTV_LEN];
-    uint32_t value = be32_to_cpu(interval_seconds);
 
     cleaning_command[0] = SPS30_SUBCMD_READ_FAN_CLEAN_INTV;
-    for (ix = 0; ix < sizeof(uint32_t); ix++)
-        cleaning_command[ix + 1] = (uint8_t)(value >> (8 * ix));
-    return sensirion_shdlc_xcv(
-        SPS30_ADDR, SPS30_CMD_FAN_CLEAN_INTV, sizeof(cleaning_command),
-        (const uint8_t*)cleaning_command, sizeof(interval_seconds), &header,
-        (uint8_t*)&interval_seconds);
+    sensirion_uint32_t_to_bytes(interval_seconds, &cleaning_command[1]);
+
+    return sensirion_shdlc_xcv(SPS30_ADDR, SPS30_CMD_FAN_CLEAN_INTV,
+                               sizeof(cleaning_command), cleaning_command, 0,
+                               &header, NULL);
 }
 
 int16_t sps30_get_fan_auto_cleaning_interval_days(uint8_t* interval_days) {

--- a/sps30-uart/sps30.c
+++ b/sps30-uart/sps30.c
@@ -155,14 +155,15 @@ int16_t sps30_get_fan_auto_cleaning_interval(uint32_t* interval_seconds) {
     struct sensirion_shdlc_rx_header header;
     uint8_t tx_data[] = {SPS30_SUBCMD_READ_FAN_CLEAN_INTV};
     int16_t ret;
+    uint8_t data[4];
 
     ret = sensirion_shdlc_xcv(
         SPS30_ADDR, SPS30_CMD_FAN_CLEAN_INTV, sizeof(tx_data), tx_data,
-        sizeof(*interval_seconds), &header, (uint8_t*)interval_seconds);
+        sizeof(*interval_seconds), &header, (uint8_t*)data);
     if (ret < 0)
         return ret;
 
-    *interval_seconds = be32_to_cpu(*interval_seconds);
+    *interval_seconds = sensirion_bytes_to_uint32_t(data);
 
     if (header.state)
         return SPS30_ERR_STATE(header.state);

--- a/sps30-uart/sps30.c
+++ b/sps30-uart/sps30.c
@@ -100,55 +100,33 @@ int16_t sps30_stop_measurement(void) {
 
 int16_t sps30_read_measurement(struct sps30_measurement* measurement) {
     struct sensirion_shdlc_rx_header header;
-    int16_t ret;
-    uint16_t idx;
-    union {
-        uint16_t u16_value[2];
-        uint32_t u32_value;
-        float f32_value;
-    } val, data[10];
+    int16_t error;
+    uint8_t data[10][4];
 
-    ret = sensirion_shdlc_xcv(SPS30_ADDR, SPS30_CMD_READ_MEASUREMENT, 0, NULL,
-                              sizeof(data), &header, (uint8_t*)data);
-    if (ret)
-        return ret;
+    error = sensirion_shdlc_xcv(SPS30_ADDR, SPS30_CMD_READ_MEASUREMENT, 0, NULL,
+                                sizeof(data), &header, (uint8_t*)data);
+    if (error) {
+        return error;
+    }
 
-    if (header.data_len != sizeof(data))
+    if (header.data_len != sizeof(data)) {
         return SPS30_ERR_NOT_ENOUGH_DATA;
+    }
 
-    idx = 0;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->mc_1p0 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->mc_2p5 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->mc_4p0 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->mc_10p0 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->nc_0p5 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->nc_1p0 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->nc_2p5 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->nc_4p0 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->nc_10p0 = val.f32_value;
-    ++idx;
-    val.u32_value = be32_to_cpu(data[idx].u32_value);
-    measurement->typical_particle_size = val.f32_value;
+    measurement->mc_1p0 = sensirion_bytes_to_float(data[0]);
+    measurement->mc_2p5 = sensirion_bytes_to_float(data[1]);
+    measurement->mc_4p0 = sensirion_bytes_to_float(data[2]);
+    measurement->mc_10p0 = sensirion_bytes_to_float(data[3]);
+    measurement->nc_0p5 = sensirion_bytes_to_float(data[4]);
+    measurement->nc_1p0 = sensirion_bytes_to_float(data[5]);
+    measurement->nc_2p5 = sensirion_bytes_to_float(data[6]);
+    measurement->nc_4p0 = sensirion_bytes_to_float(data[7]);
+    measurement->nc_10p0 = sensirion_bytes_to_float(data[8]);
+    measurement->typical_particle_size = sensirion_bytes_to_float(data[9]);
 
-    if (header.state)
+    if (header.state) {
         return SPS30_ERR_STATE(header.state);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Check the following:

 - [na] Breaking changes marked in commit message
 - [X] Changelog updated
 - [X] Code style cleaned (ran `make style-fix`)
 - [x] Tested on actual hardware
