### PR TITLE
Allow to redefine the UART device to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  * [`changed`] Use configuration independent endianness conversions: no need to
                define `SENSIRION_BIG_ENDIAN` anymore.
+ * [`changed`] Allow to override the TTY device to use in the Linux UART sample
+               implementation.
 
 ## [3.1.0] - 2020-07-03
 

--- a/docs/getting-started-on-the-raspberry-pi.md
+++ b/docs/getting-started-on-the-raspberry-pi.md
@@ -51,10 +51,11 @@ $ cd sps30-uart-3.1.0
 $ cp sample-implementations/linux/sensirion_uart_implementation.c sensirion_uart_implementation.c
 ```
 
-Then in `sensirion_uart_implementation.c` change the line with `#define TTYDEV`
-to match the device you got from the step before.
+Then in `sensirion_uart_implementation.c` change the line with
+`#define SENSIRION_UART_TTYDEV` to match the device you got from the step
+before.
 ```c
-#define TTYDEV "/dev/ttyUSB0"
+#define SENSIRION_UART_TTYDEV "/dev/ttyUSB0"
 ```
 
 ## Compile and Run

--- a/embedded-uart-common/sample-implementations/linux/sensirion_uart_implementation.c
+++ b/embedded-uart-common/sample-implementations/linux/sensirion_uart_implementation.c
@@ -39,7 +39,9 @@
 // Adapted from
 // http://www.raspberry-projects.com/pi/programming-in-c/uart-serial-port/using-the-uart
 
-#define TTYDEV "/dev/ttyUSB0"
+#ifndef SENSIRION_UART_TTYDEV
+#define SENSIRION_UART_TTYDEV "/dev/ttyUSB0"
+#endif
 
 static int uart_fd = -1;
 
@@ -68,7 +70,7 @@ int16_t sensirion_uart_open() {
     //    O_NOCTTY - When set and path identifies a terminal device, open()
     //      shall not cause the terminal device to become the controlling
     //      terminal for the process.
-    uart_fd = open(TTYDEV, O_RDWR | O_NOCTTY);
+    uart_fd = open(SENSIRION_UART_TTYDEV, O_RDWR | O_NOCTTY);
     if (uart_fd == -1) {
         fprintf(stderr, "Error opening UART. Ensure it's not otherwise used\n");
         return -1;


### PR DESCRIPTION
Also rename the define to namespace it.

Check the following:

 - [na] Breaking changes marked in commit message
 - [X] Changelog updated
 - [X] Code style cleaned (ran `make style-fix`)
 - [X] Tested on actual hardware
