### PR TITLE
Fix: don't copy test files to release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [`removed`] Remove test-config folder from release
+
 ## [3.3.0] - 2020-12-09
 
  * [`added`]   SEN44 Support

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ $(release_drivers): sps-common/sps_git_version.c
 	export pkgname="$${driver}-$${tag}" && \
 	export pkgdir="release/$${pkgname}" && \
 	rm -rf "$${pkgdir}" && mkdir -p "$${pkgdir}" && \
-	cp -r embedded-uart-common/* "$${pkgdir}" && \
+	cp embedded-uart-common/*.[ch] "$${pkgdir}" && \
+	cp -r embedded-uart-common/sample-implementations "$${pkgdir}" && \
 	cp -r sps-common/* "$${pkgdir}" && \
 	cp -r $${driver}/* "$${pkgdir}" && \
 	cp CHANGELOG.md LICENSE "$${pkgdir}" && \


### PR DESCRIPTION
Don't copy the test-config folder from embedded-uart-common over to
the release. Only copy sources, headers and the sample-implementations
folder.

Check the following:

 - [-] Breaking changes marked in commit message
 - [x] Changelog updated
 - [x] Code style cleaned (ran `make style-fix`)
 - [-] Tested on actual hardware
